### PR TITLE
Fix dynamic save behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ const form = saveform("#my-form");
 form.save();
 ```
 
+`save()` merges the current form values with any data already in storage. This ensures values
+from fields that were removed from the DOM (for example, in dynamic forms) remain intact.
+
 #### restore()
 
 Manually restore saved values.

--- a/saveform.js
+++ b/saveform.js
@@ -117,6 +117,9 @@ export default function saveform(element, options = {}) {
   function save() {
     const fields = findFields();
     let data = {};
+    try {
+      data = JSON.parse(config.storage.getItem(storageKey) || "{}");
+    } catch {}
 
     // Collect values from all fields
     fields.forEach((field) => {

--- a/test.js
+++ b/test.js
@@ -885,3 +885,28 @@ tap.test("saveform - select[multiple] restoring an empty array", (t) => {
 
   t.end();
 });
+
+tap.test("saveform - dynamic fields retain values", (t) => {
+  setupDOM(`
+    <form id="dyn">
+      <input type="text" name="a" value="1">
+      <input type="text" name="b" value="2">
+    </form>
+  `);
+  localStorage.clear();
+  const f = saveform("#dyn");
+
+  f.save();
+  document.querySelector('[name="b"]').remove();
+  document.querySelector('[name="a"]').value = "x";
+
+  t.same(f.save(), { a: "x", b: "2" }, "save() merges with stored values");
+
+  const b = document.createElement("input");
+  b.name = "b";
+  document.querySelector("#dyn").appendChild(b);
+
+  f.restore();
+  t.equal(document.querySelector('[name="b"]').value, "2", "restore() reuses old value");
+  t.end();
+});


### PR DESCRIPTION
## Summary
- preserve existing data when calling `save()`
- add test case for dynamic form fields
- document how `save()` merges with stored data

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68419550a1e4832cbeb8a9b22d36cb7f